### PR TITLE
Refs #44 Do not get all hostname variations on Debian

### DIFF
--- a/Dockerfiles/data/docker-entrypoint.sh
+++ b/Dockerfiles/data/docker-entrypoint.sh
@@ -49,7 +49,7 @@ if [ -f "/etc/alpine-release" ]; then
 	DEFAULT_MNAME="$( hostname -f | sed 's/\s$//g' | xargs -0 )"
 else
 	# Debian
-	DEFAULT_MNAME="$( hostname -A | sed 's/\s$//g' | xargs -0 )"
+	DEFAULT_MNAME="$( hostname -f | sed 's/\s$//g' | xargs -0 )"
 fi
 
 


### PR DESCRIPTION
# Do not get all hostname variations on Debian

Instead of getting all hostnames via `hostname -A`, it was supposed to only get the fqdn `hostname -f`.

* Fixes: https://github.com/cytopia/docker-bind/issues/44